### PR TITLE
Fix qnodes moved in Wikidata and DWD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### Changes (2022-12-23)
+
+Entity node changes in Wikidata required changes in the overlay.
+
+#### Qnodes changed
+
+- right_Q22059430 --> right_Q2386606
+- equipment_Q16798631 --> equipment_Q10273457
+
 ### Changes (2022-12-06)
 
 Entity and event node additions based on suggestions from ISI, plus a handful of relations.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ The DWD overlay is a subset of the DWD along with mappings to PropBank rolesets,
 
 ## Changelog
 
+### Changes (2022-12-23)
+
+Entity node changes in Wikidata required changes in the overlay.
+
+#### Qnodes changed
+
+- right_Q22059430 --> right_Q2386606
+- equipment_Q16798631 --> equipment_Q10273457
+
 ### Changes (2022-12-06)
 
 Entity and event node additions based on suggestions from ISI, plus a handful of relations.


### PR DESCRIPTION
I am in the process of updating to [XPO overlay v5.3](https://github.com/e-spaulding/xpo/releases/tag/v5.3), and I found two errors using our internal validation. In both cases, they are caused by using qnodes that were moved in Wikidata and DWD. They are as follows:

- `Q22059430` -> [`Q2386606`](https://www.wikidata.org/wiki/Q2386606) ("right")
- `Q16798631` -> [`Q10273457`](https://www.wikidata.org/wiki/Q10273457) ("equipment")

The changelog and README were updated to note the change.

Don't worry about rushing out a new release for us. ISI will not be ready to update to XPO v5.3 until mid-January at the earliest. I was just doing some preparation work now to catch any problems with the overlay before we actually start using it.